### PR TITLE
Windows: Wire up windows to work with 'esy pesy' and 'esy build'

### DIFF
--- a/pesy-header.sh
+++ b/pesy-header.sh
@@ -11,7 +11,24 @@ YELLOW=`tput setaf 3` || YELLOW=''
 RESET=`tput sgr0` || RESET=''
 
 MODE="update"
-[[ $SHELL =~ "noprofile" ]] && MODE="build"
+
+# On Windows, the 'esy pesy' syntax doesn't work as we want it to -
+# our bash environment there is always run with 'noprofile',
+# so 'pesy' always runs in build mode instead of update mode.
+
+# To make this command work cross-platform, we add a way to override
+# the mode via the 'PESY_MODE' environment variable.
+
+set +u
+if [ ! -z "${PESY_MODE}" ]; then
+  printf "PESY MODE"
+  MODE="$PESY_MODE"
+else 
+  if [[ $SHELL =~ "noprofile" ]]; then
+    MODE="build"
+  fi
+fi
+set -u
 
 
 LAST_EXE_NAME=""

--- a/pesy-header.sh
+++ b/pesy-header.sh
@@ -30,7 +30,6 @@ else
 fi
 set -u
 
-
 LAST_EXE_NAME=""
 NOTIFIED_USER="false"
 BUILD_STALE_PROBLEM="false"

--- a/pesy-package.template.json
+++ b/pesy-package.template.json
@@ -27,6 +27,7 @@
     }
   },
   "scripts": {
+    "pesy": "bash -c 'env PESY_MODE=update pesy'",
     "test": "esy x Test<PACKAGE_NAME_UPPER_CAMEL>.exe"
   },
   "dependencies": {


### PR DESCRIPTION
__Issue:__ Right now, `pesy`-generated projects aren't really usable on Windows. If someone creates a `pesy` project, and pushes it to Git, the synchronization with `esy pesy` doesn't work correctly.

This change enables `esy pesy` to run as expected on Windows.

Right now, we check the `$SHELL` variable to see if we're running in a `noprofile` shell. On OSX / Linux, `noprofile` means we're running in the build environment. However, on Windows, we always run in a `noprofile` shell, so this isn't a good means to differentiate at the moment.

__Fix:__ Add an escape-hatch environment variable `PESY_MODE` that overrides the `mode`. We then use this with a `pesy` script to make everything work the same on Windows/OSX/Linux when running `esy pesy`.
