### PR TITLE
Add _esy/ folder and symlinked node folder to .gitignore

### DIFF
--- a/pesy-gitignore.template
+++ b/pesy-gitignore.template
@@ -1,9 +1,11 @@
 npm-debug.log
 .merlin
 yarn-error.log
+node_modules
 node_modules/
 _build
 _release
+_esy/
 <PACKAGE_NAME>.install
 .DS_Store
 *.install


### PR DESCRIPTION
With `esy@0.4.x`, there a few changes that we should account for in the `.gitignore`:
- The store for the project is in `_esy`, this shouldn't be committed
- `node_modules` is a symlink now